### PR TITLE
Upgrade management to 5.8-SNAPSHOT

### DIFF
--- a/simplecache-core/build.sbt
+++ b/simplecache-core/build.sbt
@@ -11,7 +11,7 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "commons-lang" % "commons-lang" % "2.4",
   "commons-codec" % "commons-codec" % "1.3",
-  "com.gu" % "management-core" % "1.12.1",
+  "com.gu" %% "management" % "5.8-SNAPSHOT",
   "com.gu" % "option" % "1.2",
   "com.google.collections" % "google-collections" % "1.0-rc2",
   "log4j" % "log4j" % "1.2.14"

--- a/simplecache-memcached-spring/src/main/java/com/gu/cache/memcached/MemcachedKeyTranslator.java
+++ b/simplecache-memcached-spring/src/main/java/com/gu/cache/memcached/MemcachedKeyTranslator.java
@@ -1,23 +1,22 @@
 package com.gu.cache.memcached;
 
 import com.gu.cache.simplecache.KeyTranslator;
-import com.gu.management.manifest.Manifest;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
 public class MemcachedKeyTranslator implements KeyTranslator {
-	private final Manifest manifest;
+	private final String version;
 
 	@Autowired
-	public MemcachedKeyTranslator(Manifest manifest) {
-		this.manifest = manifest;
+	public MemcachedKeyTranslator(String version) {
+		this.version = version;
 	}
 
 	public String translate(Object key) {
 		try {
-			return String.format("%s:%s", manifest.getRevisionNumber(), URLEncoder.encode(String.valueOf(key),"US-ASCII"));
+			return String.format("%s:%s", version, URLEncoder.encode(String.valueOf(key),"US-ASCII"));
 		} catch (UnsupportedEncodingException e) {
 			throw new RuntimeException(e);
 		}

--- a/simplecache-memcached-spring/src/main/java/com/gu/cache/memcached/SpyMemcachedClientFactoryBean.java
+++ b/simplecache-memcached-spring/src/main/java/com/gu/cache/memcached/SpyMemcachedClientFactoryBean.java
@@ -1,6 +1,6 @@
 package com.gu.cache.memcached;
 
-import com.gu.management.timing.TimingMetric;
+import com.gu.management.TimingMetric;
 import net.spy.memcached.ConnectionFactory;
 import net.spy.memcached.MemcachedClient;
 import org.apache.log4j.Logger;

--- a/simplecache-memcached-spring/src/test/java/com/gu/cache/memcached/MemcachedKeyTranslatorTest.java
+++ b/simplecache-memcached-spring/src/test/java/com/gu/cache/memcached/MemcachedKeyTranslatorTest.java
@@ -1,28 +1,13 @@
 package com.gu.cache.memcached;
 
-import com.gu.management.manifest.Manifest;
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.when;
 
 public class MemcachedKeyTranslatorTest {
-	private MemcachedKeyTranslator translator;
 
-	@Mock
-	private Manifest manifestMock;
-
-	@Before
-	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
-		translator = new MemcachedKeyTranslator(manifestMock);
-
-		when(manifestMock.getRevisionNumber()).thenReturn("123");
-	}
+	private MemcachedKeyTranslator translator = new MemcachedKeyTranslator("123");
 
 	@Test
 	public void shouldAddManifestRevisionNumberToKeysWithSimpleCharacters() throws Exception {
@@ -38,6 +23,5 @@ public class MemcachedKeyTranslatorTest {
 	public void shouldPerformATransformationToRemoveNonMemcachedSupportedCharacters() throws Exception {
 		assertThat(translator.translate(new StringBuilder("key with spaces")), is("123:key+with+spaces"));
 	}
-
 
 }

--- a/simplecache-memcached/src/main/java/com/gu/cache/memcached/MemcachedLoggingStopWatch.java
+++ b/simplecache-memcached/src/main/java/com/gu/cache/memcached/MemcachedLoggingStopWatch.java
@@ -1,6 +1,6 @@
 package com.gu.cache.memcached;
 
-import com.gu.management.timing.TimingMetric;
+import com.gu.management.TimingMetric;
 import org.apache.commons.lang.time.StopWatch;
 import org.apache.log4j.Logger;
 

--- a/simplecache-memcached/src/main/java/com/gu/cache/memcached/SpyMemcachedClientAdaptor.java
+++ b/simplecache-memcached/src/main/java/com/gu/cache/memcached/SpyMemcachedClientAdaptor.java
@@ -1,6 +1,6 @@
 package com.gu.cache.memcached;
 
-import com.gu.management.timing.TimingMetric;
+import com.gu.management.TimingMetric;
 import net.spy.memcached.MemcachedClientIF;
 import net.spy.memcached.MemcachedNode;
 import org.apache.log4j.Logger;

--- a/simplecache-memcached/src/test/java/com/gu/cache/memcached/MemcachedLoggingStopWatchTest.java
+++ b/simplecache-memcached/src/test/java/com/gu/cache/memcached/MemcachedLoggingStopWatchTest.java
@@ -1,6 +1,6 @@
 package com.gu.cache.memcached;
 
-import com.gu.management.timing.TimingMetric;
+import com.gu.management.TimingMetric;
 import org.apache.log4j.Logger;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
This includes changing `MemcachedKeyTranslator` a bit, so it is constructed using just a `String`. This is in part because there's no equivalent to the old `Manifest` data type. It also makes cache configuration orthogonal to the use of the build manifest.
