### PR TITLE
Release a new version which updates dependencies 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,10 @@
 name := "simplecache-all"
 
-version := "2.5-SNAPSHOT"
+version := "2.5"
 
 organization := "com.gu"
+
+scalaVersion := "2.9.2"
 
 publishTo <<= (version) { version: String =>
     val publishType = if (version.endsWith("SNAPSHOT")) "snapshots" else "releases"
@@ -18,4 +20,4 @@ maxErrors := 20
 
 javacOptions ++= Seq("-source", "1.6", "-target", "1.6")
 
-crossPaths := false
+crossPaths := true

--- a/simplecache-core/build.sbt
+++ b/simplecache-core/build.sbt
@@ -1,6 +1,8 @@
 name := "simplecache-core"
 
-version := "2.5-SNAPSHOT"
+version := "2.5"
+
+scalaVersion := "2.9.2"
 
 organization := "com.gu"
 
@@ -11,7 +13,7 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "commons-lang" % "commons-lang" % "2.4",
   "commons-codec" % "commons-codec" % "1.3",
-  "com.gu" %% "management" % "5.8",
+  "com.gu" %% "management" % "5.27",
   "com.gu" % "option" % "1.2",
   "com.google.collections" % "google-collections" % "1.0-rc2",
   "log4j" % "log4j" % "1.2.14"
@@ -19,7 +21,7 @@ libraryDependencies ++= Seq(
 
 libraryDependencies ++= Seq(
   "org.hamcrest" % "hamcrest-all" % "1.1" % "test",
-  "org.mockito" % "mockito-all" % "1.8.5" % "test",
+  "org.mockito" % "mockito-all" % "1.9.5" % "test",
   "junit" % "junit" % "4.4" % "test",
   "com.novocode" % "junit-interface" % "0.6" % "test"
 )
@@ -38,4 +40,4 @@ maxErrors := 20
 
 javacOptions ++= Seq("-source", "1.6", "-target", "1.6", "-Xlint:deprecation")
 
-crossPaths := false
+crossPaths := true

--- a/simplecache-ehcache/build.sbt
+++ b/simplecache-ehcache/build.sbt
@@ -1,6 +1,8 @@
 name := "simplecache-ehcache"
 
-version := "2.5-SNAPSHOT"
+version := "2.5"
+
+scalaVersion := "2.9.2"
 
 organization := "com.gu"
 
@@ -16,7 +18,7 @@ libraryDependencies ++= Seq(
 
 libraryDependencies ++= Seq(
   "org.hamcrest" % "hamcrest-all" % "1.1" % "test",
-  "org.mockito" % "mockito-all" % "1.8.5" % "test",
+  "org.mockito" % "mockito-all" % "1.9.5" % "test",
   "junit" % "junit" % "4.4" % "test",
   "com.novocode" % "junit-interface" % "0.6" % "test"
 )
@@ -35,4 +37,4 @@ maxErrors := 20
 
 javacOptions ++= Seq("-source", "1.6", "-target", "1.6", "-Xlint:deprecation")
 
-crossPaths := false
+crossPaths := true

--- a/simplecache-hibernate/build.sbt
+++ b/simplecache-hibernate/build.sbt
@@ -1,8 +1,10 @@
 name := "simplecache-hibernate"
 
-version := "2.5-SNAPSHOT"
+version := "2.5"
 
 organization := "com.gu"
+
+scalaVersion := "2.9.2"
 
 resolvers ++= Seq(
   "Guardian GitHub" at "http://guardian.github.com/maven/repo-releases"
@@ -15,7 +17,7 @@ libraryDependencies ++= Seq(
 
 libraryDependencies ++= Seq(
   "org.hamcrest" % "hamcrest-all" % "1.1" % "test",
-  "org.mockito" % "mockito-all" % "1.8.5" % "test",
+  "org.mockito" % "mockito-all" % "1.9.5" % "test",
   "junit" % "junit" % "4.4" % "test",
   "com.novocode" % "junit-interface" % "0.6" % "test"
 )
@@ -34,4 +36,4 @@ maxErrors := 20
 
 javacOptions ++= Seq("-source", "1.6", "-target", "1.6", "-Xlint:deprecation")
 
-crossPaths := false
+crossPaths := true

--- a/simplecache-memcached-spring/build.sbt
+++ b/simplecache-memcached-spring/build.sbt
@@ -1,8 +1,10 @@
 name := "simplecache-spring-memcached"
 
-version := "2.5-SNAPSHOT"
+version := "2.5"
 
 organization := "com.gu"
+
+scalaVersion := "2.9.2"
 
 resolvers ++= Seq(
   "Guardian GitHub" at "http://guardian.github.com/maven/repo-releases",
@@ -22,7 +24,7 @@ libraryDependencies ++= Seq(
 
 libraryDependencies ++= Seq(
   "org.hamcrest" % "hamcrest-all" % "1.1" % "test",
-  "org.mockito" % "mockito-all" % "1.8.5" % "test",
+  "org.mockito" % "mockito-all" % "1.9.5" % "test",
   "junit" % "junit" % "4.4" % "test",
   "com.novocode" % "junit-interface" % "0.6" % "test"
 )
@@ -41,4 +43,4 @@ maxErrors := 20
 
 javacOptions ++= Seq("-source", "1.6", "-target", "1.6", "-Xlint:deprecation")
 
-crossPaths := false
+crossPaths := true

--- a/simplecache-memcached/build.sbt
+++ b/simplecache-memcached/build.sbt
@@ -1,8 +1,10 @@
 name := "simplecache-memcached"
 
-version := "2.5-SNAPSHOT"
+version := "2.5"
 
 organization := "com.gu"
+
+scalaVersion := "2.9.2"
 
 resolvers ++= Seq(
   "Guardian GitHub" at "http://guardian.github.com/maven/repo-releases",
@@ -20,7 +22,7 @@ libraryDependencies ++= Seq(
 
 libraryDependencies ++= Seq(
   "org.hamcrest" % "hamcrest-all" % "1.1" % "test",
-  "org.mockito" % "mockito-all" % "1.8.5" % "test",
+  "org.mockito" % "mockito-all" % "1.9.5" % "test",
   "junit" % "junit" % "4.4" % "test",
   "com.novocode" % "junit-interface" % "0.6" % "test"
 )
@@ -39,4 +41,4 @@ maxErrors := 20
 
 javacOptions ++= Seq("-source", "1.6", "-target", "1.6", "-Xlint:deprecation")
 
-crossPaths := false
+crossPaths := true


### PR DESCRIPTION
Bump dependencies to:
- scala runtime: 2.9.2
- guardian management: 5.27
- mockito: 1.9.5

Publish as well with cross path, to avoid classpath problems at runtime, with mixed scala versions. 
